### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.7-alpine
 
+RUN apk add --no-cache jpeg-dev zlib-dev
+RUN apk add --no-cache --virtual .build-deps build-base linux-headers \
+    && pip install Pillow
 RUN pip install -U geektime_dl
 
 WORKDIR /output


### PR DESCRIPTION
原 Dockerfile 会导致 Pillow 安装失败，更新后添加了安装依赖项